### PR TITLE
Use asyncinject settings for production environment.

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -64,6 +64,15 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
+    // Testem prefers this...
+    ENV.baseURL = '/';
+
+    // keep test console output quieter
+    ENV.APP.LOG_ACTIVE_GENERATION = false;
+    ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+    ENV.locationType = 'hash';
+    ENV.APP.rootElement = '#summer-app';
   }
 
   return ENV;


### PR DESCRIPTION
Allows the production build to be deployed the same as the asyncinject, but prod build is minified so it's faster loading.