### PR TITLE
Fix: Use correct path on linkTo for the 'finish' button.

### DIFF
--- a/app/templates/components/pagination-nav.hbs
+++ b/app/templates/components/pagination-nav.hbs
@@ -20,7 +20,7 @@
             <span aria-hidden="true" style="padding-right: 25px" {{action "saveTags"}}>Next</span>
         {{/link-to}}
       {{else}}
-        {{#link-to 'index.results' chapter.id classNames="bgNextArrow"}}
+        {{#link-to 'index.chapter.results' chapter.id classNames="bgNextArrow"}}
             <span aria-hidden="true" style="padding-right: 25px" {{action "saveTags"}}>Finish!</span>
         {{/link-to}}
       {{/if}}


### PR DESCRIPTION
This caused the 'finish' button to not show up.
(cherry picked from commit d05832a8b9824cf06dfefec31164ee2c68103485)