### PR TITLE
Nullify sequence number on welcome page.

### DIFF
--- a/app/routes/index/chapter.js
+++ b/app/routes/index/chapter.js
@@ -11,9 +11,14 @@ export default Ember.Route.extend({
       if (progress.chapter_id === parseInt(chapter.id)) {
         hasProgress = true;
 
-        // A null sequence number is the welcome page, so don't transition to a question
         if (progress.sequence_num) {
+
+          // A non-null sequence number represents the last place visited was a question
           this.transitionTo('index.chapter.question', chapter.id, progress.sequence_num); // And go there
+        } else {
+
+          // A null sequence number represents the last place visited was not a question
+          this.transitionTo('index.chapter.welcome', chapter.id); // And go to welcome page
         }
       }
     });

--- a/app/routes/index/chapter/results.js
+++ b/app/routes/index/chapter/results.js
@@ -14,6 +14,8 @@ export default Ember.Route.extend({
     var chapter = this.modelFor('index/chapter').chapter,
       member = this.modelFor('index').member;
 
+    // A null sequence_num represents the last question visited wasn't a question, but rather any other child route of
+    // the index.chapter route.
     this.get('paginationNav').update(member, chapter, null); // Update pagination nav to null
 
       return Ember.RSVP.hash({

--- a/app/routes/index/chapter/welcome.js
+++ b/app/routes/index/chapter/welcome.js
@@ -1,4 +1,13 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  paginationNav: Ember.inject.service('pagination-nav'),
+  beforeModel() {
+    var member = this.modelFor('index/chapter').member,
+      chapter = this.modelFor('index/chapter').chapter;
+
+    // A null sequence_num represents the last question visited wasn't a question, but rather any other child route of
+    // the index.chapter route.
+    this.get('paginationNav').update(member, chapter, null); // Update pagination nav
+  }
 });


### PR DESCRIPTION
This hides the pagination when manually revisiting the welcome page. It is a more proper way of handling state because all of the chapter's routes must update the pagination nav via the pagination nav service. As of this commit, that is welcome, question, and results routes.

May need refactor by moving updating pagination to something that automatically does it upon any transition within the index.chapter route. The member, the chapter, and the sequence number are all available before going into and moving between children of index.chapter route.