### PR TITLE
Feature/restart chapter

### DIFF
--- a/app/routes/index/chapter.js
+++ b/app/routes/index/chapter.js
@@ -46,5 +46,25 @@ export default Ember.Route.extend({
       chapter_progress.status = status; // Update progress marker's status flag as 'none', 'started', 'completed', or 'unqualified'
       member.save(); // Explicitly save member because status is not observable
     },
+    restart(member, chapter) {
+      Ember.Logger.log('Restarting chapter here...');
+
+      var chapter_progress = member.get('progresses').filterBy('chapter_id', parseInt(chapter.id)).objectAt(0);
+
+      chapter_progress.status = 'none'; // Update progress marker's status flag as 'none'
+      member.save(); // Explicitly save member because status is not observable
+
+      var chapter_tags = member.get('tags').filterBy('chapterId', parseInt(chapter.id)); // Get tags for this chapter
+
+      chapter_tags.forEach(tag => {
+
+        // Delete this tag's local storage
+        this.set('storage.tag[' + member.id + '][' + chapter.id + '][' + tag.get('questionId') +']', null);
+
+        tag.destroyRecord(); // Delete tag
+      });
+
+      this.transitionTo('index.chapter.welcome', chapter.id); // And go to welcome page
+    }
   },
 });

--- a/app/templates/index/chapter.hbs
+++ b/app/templates/index/chapter.hbs
@@ -4,13 +4,6 @@
     <h1>{{model.chapter.title}}</h1>
   </div>
 </div>
-<div class="row">
-    <div class="col-xs-12">
-      {{#link-to 'index.chapter.welcome' model.chapter.id}}
-          <span aria-hidden="true" {{action "restart" model.member model.chapter}}>Restart</span>
-      {{/link-to}}
-    </div>
-</div>
 
 {{outlet}}
 

--- a/app/templates/index/chapter.hbs
+++ b/app/templates/index/chapter.hbs
@@ -4,6 +4,13 @@
     <h1>{{model.chapter.title}}</h1>
   </div>
 </div>
+<div class="row">
+    <div class="col-xs-12">
+      {{#link-to 'index.chapter.welcome' model.chapter.id}}
+          <span aria-hidden="true" {{action "restart" model.member model.chapter}}>Restart</span>
+      {{/link-to}}
+    </div>
+</div>
 
 {{outlet}}
 

--- a/app/templates/index/chapter/results.hbs
+++ b/app/templates/index/chapter/results.hbs
@@ -1,3 +1,11 @@
+<div class="row">
+    <div class="col-xs-12">
+      {{#link-to 'index.chapter.welcome' model.chapter.id}}
+          <span aria-hidden="true" {{action "restart" model.member model.chapter}}>Restart</span>
+      {{/link-to}}
+    </div>
+</div>
+
 <h2>Thank you</h2>
 
 <p>We have completed the health assessment.</p>

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -25,6 +25,8 @@ export default function() {
 
   this.get('/tags/:id');
 
+  this.delete('/tags/:id');
+
   this.namespace = '/api/v1';
 
   this.get('/members', ({ members }, request) => {


### PR DESCRIPTION
Chapter can be restarted by clicking 'Restart' on Results page. This sets their progress marker status to 'none', deletes that chapter's tags, and deletes the local storage tags for those tags, then goes to the welcome page.