### PR TITLE
Infra/api adapters

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,0 +1,5 @@
+import JSONAPIAdapter from 'ember-data/adapters/json-api';
+
+export default JSONAPIAdapter.extend({
+  namespace: '/ws/ajax/v1' // summer app's external API prefix
+});

--- a/app/adapters/member.js
+++ b/app/adapters/member.js
@@ -1,0 +1,9 @@
+import JSONAPIAdapter from 'ember-data/adapters/json-api';
+
+export default JSONAPIAdapter.extend({
+  namespace: '/ws/ajax/v1', // summer app's external API prefix
+  buildURL (modelName, id) {
+
+    return this.namespace + '/members/' + id;
+  },
+});

--- a/app/adapters/tag.js
+++ b/app/adapters/tag.js
@@ -1,0 +1,4 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+});

--- a/app/adapters/tag.js
+++ b/app/adapters/tag.js
@@ -1,4 +1,8 @@
 import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
+  namespace: '/ws/ajax/v1', // summer app's external API prefix
+  buildURL (modelName, id, snapshot, requestType, query) {
+    return this.namespace + '/responses';
+  }
 });

--- a/app/adapters/tag.js
+++ b/app/adapters/tag.js
@@ -1,8 +1,15 @@
-import ApplicationAdapter from './application';
+import JSONAPIAdapter from 'ember-data/adapters/json-api';
 
-export default ApplicationAdapter.extend({
+export default JSONAPIAdapter.extend({
   namespace: '/ws/ajax/v1', // summer app's external API prefix
   buildURL (modelName, id, snapshot, requestType, query) {
+
+    // Solarium API translation
+    if (query && query.chapterId) {
+      query.surveyId = query.chapterId;
+      delete query.chapterId;
+    }
+
     return this.namespace + '/responses';
-  }
+  },
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -59,7 +59,8 @@ export default Ember.Route.extend({
   },
   model() {
     return Ember.RSVP.hash({
-      member: this.store.findRecord('member', 4, { include: 'tags' }), // Get the member's record
+      member: this.store.findRecord('member', 4), //@TODO: Get the member's tags using findRecord 'include'
+      tags: this.store.query('tag', { memberId: 4, chapterId: 102 }), //@TODO: Get tags via the member's relationship
       consequence_links: this.store.findAll('consequenceLink'),
     });
   }

--- a/app/routes/index/chapter/question.js
+++ b/app/routes/index/chapter/question.js
@@ -20,17 +20,6 @@ export default Ember.Route.extend({
 
     member.save(); // Save current progress in the member
 
-    Ember.$.ajax({
-      method: "POST",
-      url: "/api/v1/responses",
-      contentType: "application/json",
-      data: JSON.stringify({
-        member: member,
-      })
-    });
-
-    //@TODO: Send member data to /ws/ajax endpoint as well, once it is decided.
-
     // We don't know the ID of the current question yet,
     // just that it's nth question on the current chapter.
     var question = chapter.get('questions').objectAt(sequence_num - 1);
@@ -148,18 +137,6 @@ export default Ember.Route.extend({
 
       // Update the ember-storage (localStorage or sessionStorage) value with tag value to keep them in sync
       this.set('storage.tag[' + member.id + '][' + chapter.id + '][' + question.id +']', tag.get('answer'));
-
-      Ember.$.ajax({
-        method: "POST",
-        url: "/api/v1/responses",
-        contentType: "application/json",
-        data: JSON.stringify({
-          memberId: member.id,
-          chapterId: chapter.id,
-          questionId: question.id,
-          answer: answers,
-        })
-      });
 
       Ember.$.ajax({
         type: "POST",

--- a/app/routes/index/chapter/question.js
+++ b/app/routes/index/chapter/question.js
@@ -60,6 +60,7 @@ export default Ember.Route.extend({
       options = question.get('options');
 
       tag.set('answer', answers); // Reset tag
+      tag.save(); // Persist data to API
 
       // Set question's options to unselected
       options.forEach(option => {
@@ -79,6 +80,7 @@ export default Ember.Route.extend({
       Ember.Logger.log("Updating tag locally goes here...");
 
       tag.set('answer', [option.get('value')]);
+      tag.save(); // Persist data to API
 
       // Update the ember-storage (localStorage or sessionStorage) value with tag value to keep them in sync
       this.set('storage.tag[' + member.id + '][' + chapter.id + '][' + question.id +']', tag.get('answer'));
@@ -134,6 +136,7 @@ export default Ember.Route.extend({
       }
 
       tag.set('answer', answers);
+      tag.save(); // Persist data to API
 
       // Update the ember-storage (localStorage or sessionStorage) value with tag value to keep them in sync
       this.set('storage.tag[' + member.id + '][' + chapter.id + '][' + question.id +']', tag.get('answer'));

--- a/app/routes/index/chapter/question.js
+++ b/app/routes/index/chapter/question.js
@@ -145,35 +145,11 @@ export default Ember.Route.extend({
     saveTags(member) {
       Ember.Logger.log("Saving all tags locally goes here...");
 
-      var tags = [];
-      member.get('tags').forEach(function(tag) {
-        tags.push({
-          memberId: member.id,
-          chapterId: tag.get('chapterId'),
-          questionId: tag.get('questionId'),
-          answer: tag.get('answer'),
-        });
+      var tags = member.get('tags');
+
+      tags.forEach(function(tag) {
+        tag.save(); // Persist data to API
       });
-
-      var tags_alt,
-        questions_alt = [],
-        chapter_id_alt = -1; //@TODO: Due to the way the API receives data, this has to be extracted, but this assumes all of them are from the same chapter
-
-      member.get('tags').forEach(function(tag) {
-        chapter_id_alt = tag.get('chapterId'); //@TODO: Always assigns to last tag in the list
-
-        questions_alt.push({
-          "questionId": tag.get('questionId'),
-          "questionNumber": -1, //@TODO: Question number not yet needed, but it is required by API
-          "response": tag.get('answer').toString()
-        });
-      });
-
-      tags_alt = {
-        memberId: member.id, //@TODO: Member ID should not be sent over http
-        surveyId: chapter_id_alt,
-        questions: questions_alt
-      };
     },
   },
 });

--- a/app/routes/index/chapter/question.js
+++ b/app/routes/index/chapter/question.js
@@ -140,24 +140,6 @@ export default Ember.Route.extend({
 
       // Update the ember-storage (localStorage or sessionStorage) value with tag value to keep them in sync
       this.set('storage.tag[' + member.id + '][' + chapter.id + '][' + question.id +']', tag.get('answer'));
-
-      Ember.$.ajax({
-        type: "POST",
-        data: JSON.stringify({
-          memberId: member.id, //@TODO: Member ID should not be sent over http
-          surveyId: chapter.id,
-          questions: [
-            {
-              "questionId": question.id,
-              "questionNumber": -1,
-              "response": answers.toString()
-            }
-          ]
-        }),
-        contentType: "application/json",
-        url: "/ws/ajax/v1/responses",
-      });
-
       return true;
     },
     saveTags(member) {
@@ -192,13 +174,6 @@ export default Ember.Route.extend({
         surveyId: chapter_id_alt,
         questions: questions_alt
       };
-
-      Ember.$.ajax({
-        method: "POST",
-        contentType: "application/json",
-        url: "/ws/ajax/v1/responses",
-        data: JSON.stringify(tags_alt),
-      });
     },
   },
 });

--- a/app/serializers/member.js
+++ b/app/serializers/member.js
@@ -4,7 +4,7 @@ export default DS.JSONSerializer.extend({
 
   // Modify "member" object
   // Only used for 'findRecord' requests, such as: this.store.findRecord('member', 4) .
-  normalizeFindRecordResponse(store, primaryModelClass, payload, id, requestType) {
+  normalizeFindRecordResponse(store, primaryModelClass, payload) {
     var member = payload.member;
 
     return {
@@ -18,7 +18,7 @@ export default DS.JSONSerializer.extend({
 
   // Modify "member" object
   // Only used for sending data, such as: member.save() .
-  serialize: function(snapshot, options) {
+  serialize: function(snapshot) {
     var json = snapshot.attributes();
     json.id = snapshot.id;
 

--- a/app/serializers/member.js
+++ b/app/serializers/member.js
@@ -1,0 +1,27 @@
+import DS from 'ember-data';
+
+export default DS.JSONSerializer.extend({
+
+  // Modify "member" object
+  // Only used for 'findRecord' requests, such as: this.store.findRecord('member', 4) .
+  normalizeFindRecordResponse(store, primaryModelClass, payload, id, requestType) {
+    var member = payload.member;
+
+    return {
+      data: {
+        type: 'member',
+        id: parseInt(member.id),
+        attributes: member,
+      },
+    };
+  },
+
+  // Modify "member" object
+  // Only used for sending data, such as: member.save() .
+  serialize: function(snapshot, options) {
+    var json = snapshot.attributes();
+    json.id = snapshot.id;
+
+    return json;
+  },
+});

--- a/app/serializers/tag.js
+++ b/app/serializers/tag.js
@@ -1,6 +1,33 @@
 import DS from 'ember-data';
 
 export default DS.JSONSerializer.extend({
+
+  // Modify "response" objects to become "tag" objects.
+  // Only used for 'query' requests, such as: this.store.query('tag', { memberId: 4, chapterId: 102 }) .
+  normalizeQueryResponse(store, primaryModelClass, payload, id, requestType) {
+    var tags = [],
+      responses = payload.responses;
+
+    responses.forEach(function(response) {
+      tags.push({
+        type: 'tag',
+        id: parseInt(response.id),
+        attributes: {
+          chapterId: parseInt(response.surveyId),
+          questionId: parseInt(response.questions.questionId),
+          answer: response.questions.response,
+          questionNumber: -1,
+        },
+      });
+    });
+
+    return {
+      data: tags,
+    };
+  },
+
+  // Modify "tag" objects to become "response" objects.
+  // Only used for sending data, such as: tag.save() .
   serialize: function(snapshot, options) {
     var json = {
       surveyId: snapshot.attr('chapterId'),

--- a/app/serializers/tag.js
+++ b/app/serializers/tag.js
@@ -1,0 +1,16 @@
+import DS from 'ember-data';
+
+export default DS.JSONSerializer.extend({
+  serialize: function(snapshot, options) {
+    var json = {
+      surveyId: snapshot.attr('chapterId'),
+      questions: {
+        questionId: snapshot.attr('questionId').toString(),
+        questionNumber: -1, //@TODO: Not yet needed in summer-app
+        response: snapshot.attr('answer'),
+      },
+    };
+
+    return json;
+  }
+});

--- a/app/serializers/tag.js
+++ b/app/serializers/tag.js
@@ -4,7 +4,7 @@ export default DS.JSONSerializer.extend({
 
   // Modify "response" objects to become "tag" objects.
   // Only used for 'query' requests, such as: this.store.query('tag', { memberId: 4, chapterId: 102 }) .
-  normalizeQueryResponse(store, primaryModelClass, payload, id, requestType) {
+  normalizeQueryResponse(store, primaryModelClass, payload) {
     var tags = [],
       responses = payload.responses;
 
@@ -28,7 +28,7 @@ export default DS.JSONSerializer.extend({
 
   // Modify "tag" objects to become "response" objects.
   // Only used for sending data, such as: tag.save() .
-  serialize: function(snapshot, options) {
+  serialize: function(snapshot) {
     var json = {
       surveyId: snapshot.attr('chapterId'),
       questions: {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,7 +1,5 @@
 export default function() {
 
-  this.passthrough('/api/v1/responses'); // This will be the endpoint that receives the member responses
-
   this.namespace = '/ws/ajax/v1'; // summer app's external API prefix
 
   this.passthrough('/responses');

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -10,7 +10,7 @@ export default function() {
 
   this.get('/members/:id');
 
-  this.patch('/members/:id');
+  this.passthrough('/members/:id' , ['patch']);
 
   this.get('/chapters');
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -4,13 +4,13 @@ export default function() {
 
   this.get('/responses'); // Custom Solarium endpoint for tags
 
-  this.passthrough('/responses' , ['patch', 'post']); // Custom Solarium endpoint for tags, emberx-select does a PATCH
+  this.passthrough('/responses', ['patch', 'post']); // Custom Solarium endpoint for tags, emberx-select does a PATCH
 
   this.get('/consequence-links');
 
   this.get('/members/:id');
 
-  this.passthrough('/members/:id' , ['patch']);
+  this.passthrough('/members/:id', ['patch']);
 
   this.get('/chapters');
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -2,9 +2,9 @@ export default function() {
 
   this.namespace = '/ws/ajax/v1'; // summer app's external API prefix
 
-  this.passthrough('/responses');
+  this.get('/responses'); // Custom Solarium endpoint for tags
 
-  this.passthrough('/responses' , ['patch', 'post']); // custom Solarium endpoint, emberx-select does a PATCH
+  this.passthrough('/responses' , ['patch', 'post']); // Custom Solarium endpoint for tags, emberx-select does a PATCH
 
   this.get('/consequence-links');
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -18,5 +18,8 @@ export default function() {
 
   this.get('/tags/:id');
 
+  this.patch('/tags/:id'); // emberx-select does a PATCH
+  this.post('/tags');
+
   this.delete('/tags/:id');
 }

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -14,72 +14,11 @@ export default function() {
 
   this.get('/questions/:id');
 
-  this.get('/tags', ({ tags }, request) => {
-    window.console.log("in config (not namespaced): /tags");
-
-    var params = request.queryParams,
-      tags_filtered = tags.where(params);
-
-    return tags_filtered;
-  });
-
   this.get('/tags/:id');
 
   this.delete('/tags/:id');
 
   this.namespace = '/api/v1';
 
-  this.get('/members', ({ members }, request) => {
-    window.console.log("in config: /members");
-    return members.all();
-  });
-
-  this.get('/members/:id', ({ members }, request) => {
-    window.console.log("in config: /members/:id");
-    var id = request.params.id;
-    return members.find(id);
-  });
-
-  this.get('/chapters', ({ chapters }, request) => {
-    window.console.log("in config: /chapters");
-    return chapters.all();
-  });
-
-  this.get('/chapters/:id', ({ chapters }, request) => {
-    window.console.log("in config: /chapters/:id");
-    var id = request.params.id;
-    return chapters.find(id);
-  });
-
-  this.get('/chapters/:chapter_id/questions', ({ questions }, request) => {
-    window.console.log("in config: /chapters/:chapter_id/questions");
-    var chapter_id = request.params.chapter_id;
-    return questions.where({ chapterId: chapter_id });
-  });
-
   this.passthrough('/responses'); // This will be the endpoint that receives the member responses
-
-  // These comments are here to help you get started. Feel free to delete them.
-
-  /*
-    Config (with defaults).
-
-    Note: these only affect routes defined *after* them!
-  */
-
-  // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
-  // this.namespace = '';    // make this `api`, for example, if your API is namespaced
-  // this.timing = 400;      // delay for each request, automatically set to 0 during testing
-
-  /*
-    Shorthand cheatsheet:
-
-    this.get('/posts');
-    this.post('/posts');
-    this.get('/posts/:id');
-    this.put('/posts/:id'); // or this.patch
-    this.del('/posts/:id');
-
-    http://www.ember-cli-mirage.com/docs/v0.2.0-beta.7/shorthands/
-  */
 }

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -4,6 +4,8 @@ export default function() {
 
   this.passthrough('/responses');
 
+  this.passthrough('/responses' , ['patch', 'post']); // custom Solarium endpoint, emberx-select does a PATCH
+
   this.get('/consequence-links');
 
   this.get('/members/:id');
@@ -17,9 +19,6 @@ export default function() {
   this.get('/questions/:id');
 
   this.get('/tags/:id');
-
-  this.patch('/tags/:id'); // emberx-select does a PATCH
-  this.post('/tags');
 
   this.delete('/tags/:id');
 }

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,6 +1,10 @@
 export default function() {
 
-  this.passthrough('/ws/ajax/v1/responses');
+  this.passthrough('/api/v1/responses'); // This will be the endpoint that receives the member responses
+
+  this.namespace = '/ws/ajax/v1'; // summer app's external API prefix
+
+  this.passthrough('/responses');
 
   this.get('/consequence-links');
 
@@ -17,8 +21,4 @@ export default function() {
   this.get('/tags/:id');
 
   this.delete('/tags/:id');
-
-  this.namespace = '/api/v1';
-
-  this.passthrough('/responses'); // This will be the endpoint that receives the member responses
 }

--- a/mirage/models/member.js
+++ b/mirage/models/member.js
@@ -1,5 +1,5 @@
 import { Model, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
-  tags: hasMany('tag'),
+  responses: hasMany('response'),
 });

--- a/mirage/models/response.js
+++ b/mirage/models/response.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  member: belongsTo('member'),
+});

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -4,29 +4,35 @@ export default function(server) {
 
   let member = server.schema.members.find(4); // Get member "lana"
 
-  member.createTag({ questionId: 1, answer: ['yes'], chapterId: 102 });
-  member.createTag({ questionId: 11, answer: ['127'], chapterId: 102 });
-  member.createTag({ questionId: 4, answer: [null], chapterId: 102 });
-  member.createTag({ questionId: 5, answer: [null], chapterId: 102 });
-  member.createTag({ questionId: 6, answer: [null], chapterId: 102 });
-  member.createTag({ questionId: 7, answer: [null], chapterId: 102 });
-  member.createTag({ questionId: 8, answer: [null], chapterId: 102 });
-  member.createTag({ questionId: 9, answer: [null], chapterId: 102 });
-  member.createTag({ questionId: 11, answer: ['127'], chapterId: 102 });
-  member.createTag({ questionId: 13, answer: [null], chapterId: 102 });
-  member.createTag({ questionId: 3, answer: ['18-34'], chapterId: 102 });
-  member.createTag({ questionId: 4, answer: ['xoxoxoxoxoxo'], chapterId: 105 });
+  server.create('response', {
+    memberId: 4,
+    surveyId: 102,
+    questions: {
+      questionId: 11,
+      questionNumber: -1,
+      response: ['127'],
+    },
+  });
 
-  member = server.schema.members.find(1); // Get member "citizen4"
+  server.create('response', {
+    memberId: 4,
+    surveyId: 102,
+    questions: {
+      questionId: 3,
+      questionNumber: -1,
+      response: ['18-34'],
+    },
+  });
 
-  member.createTag({ questionId: 1116, answer: ['xoxoxoxoxoxo'], chapterId: 102 });
-  member.createTag({ questionId: 1123, answer: ['xoxoxoxoxoxo'], chapterId: 105 });
-  member.createTag({ questionId: 1010, answer: ['xoxoxoxoxoxo'], chapterId: 101 });
-  member.createTag({ questionId: 1116, answer: ['xoxoxoxoxoxo'], chapterId: 102 });
-  member.createTag({ questionId: 1151, answer: ['xoxoxoxoxoxo'], chapterId: 104 });
-  member.createTag({ questionId: 1152, answer: ['xoxoxoxoxoxo'], chapterId: 104 });
-  member.createTag({ questionId: 1153, answer: ['xoxoxoxoxoxo'], chapterId: 102 });
-  member.createTag({ questionId: 1154, answer: ['xoxoxoxoxoxo'], chapterId: 102 });
+  server.create('response', {
+    memberId: 4,
+    surveyId: 102,
+    questions: {
+      questionId: 4,
+      questionNumber: -1,
+      response: [null],
+    },
+  });
 
   let chapter = server.schema.chapters.find(102);
 

--- a/mirage/serializers/member.js
+++ b/mirage/serializers/member.js
@@ -1,0 +1,16 @@
+// mirage/serializers/application.js
+import { Serializer } from 'ember-cli-mirage';
+
+export default Serializer.extend({
+
+  // Solarium is custom JSON. Therefore, the data must be sent through the serializer that leaves its custom format in tact.
+  serialize(object, request) {
+
+    // This is how to call super, as Mirage borrows [Backbone's implementation of extend](http://backbonejs.org/#Model-extend)
+    let json = Serializer.prototype.serialize.apply(this, arguments);
+
+    // Add metadata, sort parts of the response, etc.
+
+    return json;
+  },
+});

--- a/mirage/serializers/response.js
+++ b/mirage/serializers/response.js
@@ -1,0 +1,16 @@
+// mirage/serializers/application.js
+import { Serializer } from 'ember-cli-mirage';
+
+export default Serializer.extend({
+
+  // Solarium is custom JSON. Therefore, the data must be sent through the serializer that leaves its custom format in tact.
+  serialize(object, request) {
+
+    // This is how to call super, as Mirage borrows [Backbone's implementation of extend](http://backbonejs.org/#Model-extend)
+    let json = Serializer.prototype.serialize.apply(this, arguments);
+
+    // Add metadata, sort parts of the response, etc.
+
+    return json;
+  },
+});

--- a/tests/unit/adapters/member-test.js
+++ b/tests/unit/adapters/member-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:member', 'Unit | Adapter | member', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/tests/unit/adapters/tag-test.js
+++ b/tests/unit/adapters/tag-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:tag', 'Unit | Adapter | tag', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/tests/unit/serializers/member-test.js
+++ b/tests/unit/serializers/member-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('member', 'Unit | Serializer | member', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:member']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/tag-test.js
+++ b/tests/unit/serializers/tag-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('tag', 'Unit | Serializer | tag', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:tag']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});


### PR DESCRIPTION
Mirage sends tags and members in a non-JSONAPI-compliant format similar to Solarium (codename for the custom API) using Mirage's adapters and serializers. Then Summer-app routes receive the objects and munge it into JSONAPI-compliant objects. Likewise, summer-app sends tags and members in a non-JSONAPI-compliant format using its adapters and serializers to endpoints that pass through Mirage and attempt to hit the actual network layer.