### PR TITLE
Get all of the member's tags from the server once, and then filter th…

### DIFF
--- a/app/routes/index/chapter.js
+++ b/app/routes/index/chapter.js
@@ -35,6 +35,10 @@ export default Ember.Route.extend({
     return Ember.RSVP.hash({
       member: this.modelFor('index').member,
       chapter: this.store.findRecord('chapter', parseInt(params.id), { include: 'questions, options' }),
+
+      // This is all the tags already received from the server plus the tags that were created from local storage, and
+      // then filtered for only this chapter.
+      tags: this.store.peekAll('tag').filterBy('chapterId', parseInt(params.id)),
     });
   },
   actions: {

--- a/app/routes/index/chapter/question.js
+++ b/app/routes/index/chapter/question.js
@@ -13,6 +13,7 @@ export default Ember.Route.extend({
   model(params) {
     var chapter = this.modelFor('index/chapter').chapter,
       member = this.modelFor('index').member,
+      tags = this.modelFor('index/chapter').tags,
       sequence_num = parseInt(params.sequence_num),
       tag;
 
@@ -24,13 +25,14 @@ export default Ember.Route.extend({
     // just that it's nth question on the current chapter.
     var question = chapter.get('questions').objectAt(sequence_num - 1);
 
-    var tags = member.get('tags')
-      .filterBy('chapterId', parseInt(chapter.id))
+    // This is all the tags already received from the server plus the tags that were created from local storage, and
+    // then filtered for only this chapter, and then filtered for only this question.
+    var question_tags = tags
       .filterBy('questionId', parseInt(question.id));
 
-    if (tags.get('length')) {
+    if (question_tags.get('length')) {
       // The tag exists, so use that one
-      tag = tags.objectAt(0);
+      tag = question_tags.objectAt(0);
       // Update the ember-storage (localStorage or sessionStorage) value with tag value to keep them in sync
       // This is only necessary if the API brought in the tag, because if it did, it has not yet been entered into
       // localStorage yet. This may be handled by the API itself, but Mirage cannot yet utilize ember-storage.


### PR DESCRIPTION
…ose according to the route's needs.

Routes were requesting tags from the server and then acting on that data, but it is possible the promise was not resolved before actions were taken on that data. This ensures that the promise is resolved at the index route level, and reduces the fetching of the tags to one call. Since the only way to CRUD tags is in routes nested under the index route, they won't get out of sync with the server.