### PR TITLE
Create custom options for questions

### DIFF
--- a/app/components/answer-tile/custom-extra.js
+++ b/app/components/answer-tile/custom-extra.js
@@ -83,7 +83,7 @@ export default Ember.Component.extend({
     this.sendAction('updateTagCustom', tag, answers);
   },
   actions: {
-    saveTag(member,chapter,question,option,tag) {
+    saveTag(member, chapter, question, option, tag) {
       this.saveTagWithSpecialCases(member, chapter, question, option, tag);
     },
   },

--- a/app/components/answer-tile/custom-extra.js
+++ b/app/components/answer-tile/custom-extra.js
@@ -1,0 +1,90 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  store: Ember.inject.service(),
+  child_question: null,
+  child_question_tag: null,
+  didReceiveAttrs() {
+    var member = this.get('member'),
+      chapter = this.get('chapter'),
+      parent_question = this.get('question'),
+
+    // The parent question must have a child question to use the custom-extra component
+      child_question = parent_question.get('questions').objectAt(0);
+
+    // Find the tag corresponding to the child question
+    let tags = member.get('tags')
+      .filterBy('chapterId', parseInt(chapter.id))
+      .filterBy('questionId', parseInt(child_question.id)),
+      tag;
+
+    // Find the corresponding tag, or create it if it doesn't exist
+    if (tags.get('length')) {
+
+      // The tag exists, so use that one
+      tag = tags.objectAt(0);
+    } else {
+
+      // The tag does not exist yet, so create it
+      tag = this.get('store').createRecord('tag', {
+        member: member,
+        chapterId: parseInt(chapter.id),
+        questionId: parseInt(child_question.id),
+        answer: [],
+      });
+    }
+
+    // Reorder options so that input is before the special options
+    let options = parent_question.get('options'),
+      index_input,
+      index_first_special_option = null,
+      option_input;
+
+    options.forEach((option, i) => {
+      if (option.get('text').indexOf('__input') === 0) {
+        index_input = i; // Mark the position of the input option
+        option_input = option; // Create reference to the input option
+      }
+    });
+
+    options.removeAt(index_input); // Remove the input option from the options list
+
+    options.forEach((option, i) => {
+      if (option.get('value').indexOf('__none') === 0 && index_first_special_option === null) {
+        index_first_special_option = i; // Mark the position of the first special option
+      }
+    });
+
+    // Insert the input option immediately before the first special option
+    options.insertAt(index_first_special_option, option_input);
+
+    // Set the properties to be used in the template
+    this.set('child_question_tag', tag);
+    this.set('child_question', child_question);
+  },
+  saveTagWithSpecialCases: function(member, chapter, question, option, tag) {
+    var answers = tag.get('answer') || [];
+
+    answers = answers.slice(0); // Force answers to be a new array to trigger observers to notice the change
+    if (answers.indexOf(option.get('value')) !== -1) { // Is this option already in the answer?
+      answers.removeObject(option.get('value')); // Remove this specific answer from answers
+    } else {
+
+      //@TODO: Don't use hardcoded strings here. There should be a method that compares answers against rules
+      answers.removeObjects(['__none-true', '__none-neutral']); // Remove special cases.
+
+      if (option.get('value').indexOf('__none') === 0) { // Is this option one of the special cases that clears the answer?
+        answers = []; // Clear the answer
+      }
+
+      answers.pushObject(option.get('value')); // Add option value to answer
+    }
+
+    this.sendAction('updateTagCustom', tag, answers);
+  },
+  actions: {
+    saveTag(member,chapter,question,option,tag) {
+      this.saveTagWithSpecialCases(member, chapter, question, option, tag);
+    },
+  },
+});

--- a/app/components/answer-tile/custom-height.js
+++ b/app/components/answer-tile/custom-height.js
@@ -1,0 +1,73 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  option_feet: 0,
+  option_inches: 0,
+  didReceiveAttrs() {
+    var question = this.get('question'),
+      options = question.get('options'),
+      tag = this.get('tag'),
+      answer = parseInt(tag.get('answer').objectAt(0)) || '';
+
+    options.forEach((option) => {
+
+      //@TODO: Don't use the freeform 'text' property to evaluate which option this is
+      // Create references to specific options so child components can reference them individually
+      switch (option.get('text')) {
+        case '__feet':
+          if (typeof answer === 'number') {
+            let feet = Math.floor(parseInt(answer) / 12);
+            option.set('value', feet);
+          } else {
+            option.set('value', '');
+          }
+          this.set('option_feet', option);
+          break;
+
+        case '__inches':
+          if (typeof answer === 'number') {
+            let inches = parseInt(answer) % 12;
+            option.set('value', inches);
+          } else {
+            option.set('value', '');
+          }
+          this.set('option_inches', option);
+          break;
+
+        default:
+          Ember.Logger.warn("Cannot create reference to option, because its option text is not recognized.");
+          break;
+      }
+    });
+  },
+  keyUp() {
+    var question = this.get('question'),
+      options = question.get('options'),
+      feet,
+      inches,
+      total_inches;
+
+    options.forEach((option) => {
+      switch (option.get('text')) {
+        case '__feet':
+          this.set('option_feet', option);
+          break;
+
+        case '__inches':
+          this.set('option_inches', option);
+          break;
+
+        default:
+          Ember.Logger.warn("Cannot create reference to option, because its option text is not recognized.");
+          break;
+      }
+    });
+
+    feet = parseInt(this.get('option_feet').get('value')) || 0;
+    inches = parseInt(this.get('option_inches').get('value')) || 0;
+
+    total_inches = (feet * 12) + inches;
+
+    this.sendAction('updateTagCustom', [total_inches]);
+  }
+});

--- a/app/components/answer-tile/custom-height.js
+++ b/app/components/answer-tile/custom-height.js
@@ -41,32 +41,9 @@ export default Ember.Component.extend({
     });
   },
   keyUp() {
-    var question = this.get('question'),
-      options = question.get('options'),
-      feet,
-      inches,
-      total_inches;
-
-    options.forEach((option) => {
-      switch (option.get('text')) {
-        case '__feet':
-          this.set('option_feet', option);
-          break;
-
-        case '__inches':
-          this.set('option_inches', option);
-          break;
-
-        default:
-          Ember.Logger.warn("Cannot create reference to option, because its option text is not recognized.");
-          break;
-      }
-    });
-
-    feet = parseInt(this.get('option_feet').get('value')) || 0;
-    inches = parseInt(this.get('option_inches').get('value')) || 0;
-
-    total_inches = (feet * 12) + inches;
+    var feet = parseInt(this.get('option_feet').get('value')) || 0,
+      inches = parseInt(this.get('option_inches').get('value')) || 0,
+      total_inches = (feet * 12) + inches;
 
     this.sendAction('updateTagCustom', [total_inches]);
   }

--- a/app/models/chapter.js
+++ b/app/models/chapter.js
@@ -7,8 +7,4 @@ export default Model.extend({
   title: attr(),
   description: attr(),
   questions: hasMany('question', {async: true}),
-  questionsLength: Ember.computed('questions', function() {
-    // A strange way to get the length of questions
-    return this.hasMany('questions').ids().length;
-  }),
 });

--- a/app/models/question.js
+++ b/app/models/question.js
@@ -8,6 +8,6 @@ export default Model.extend({
   type: attr(),
   options: hasMany('option'),
   chapter: belongsTo('chapter'),
-  questions: hasMany('question', { inverse: 'question' }),
-  question: belongsTo('question', { inverse: 'questions' }),
+  questions: hasMany('question', { inverse: 'question' }), // Relationship to its child questions
+  question: belongsTo('question', { inverse: 'questions' }), // Relationship to its parent question
 });

--- a/app/models/question.js
+++ b/app/models/question.js
@@ -8,4 +8,6 @@ export default Model.extend({
   type: attr(),
   options: hasMany('option'),
   chapter: belongsTo('chapter'),
+  questions: hasMany('question', { inverse: 'question' }),
+  question: belongsTo('question', { inverse: 'questions' }),
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  beforeModel() {
+  redirect() {
     if (this.get('router.url') === '/') {
 
       // If given no chapter, use the first chapter found
@@ -9,6 +9,8 @@ export default Ember.Route.extend({
         this.transitionTo('index.chapter.welcome', chapters.objectAt(0).id);
       });
     }
+  },
+  beforeModel() {
   },
   afterModel(model) {
     var member = model.member,

--- a/app/routes/index/chapter.js
+++ b/app/routes/index/chapter.js
@@ -1,19 +1,13 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  store: Ember.inject.service(),
   paginationNav: Ember.inject.service('pagination-nav'),
-  afterModel(model) {
+  redirect(model) {
     var member = model.member,
       chapter = model.chapter,
       progresses = member.get('progresses'),
       chapter_progress = progresses.filterBy('chapter_id', parseInt(chapter.id)).objectAt(0); // Get first matching progress
-
-    if (! chapter_progress) {
-
-      // There is no progress marker for this chapter, so create one
-      chapter_progress = { chapter_id: parseInt(chapter.id), status: 'none', sequence_num: null};
-      progresses.pushObject(chapter_progress); // Add progress marker to the member
-    }
 
     if (chapter_progress.status === 'unqualified') {
 
@@ -27,6 +21,55 @@ export default Ember.Route.extend({
 
       // A null sequence number represents the last place visited was not a question
       this.transitionTo('index.chapter.welcome', chapter.id); // And go to welcome page
+    }
+  },
+  afterModel(model) {
+    var member = model.member,
+      chapter = model.chapter,
+      progresses = member.get('progresses'),
+      chapter_progress = progresses.filterBy('chapter_id', parseInt(chapter.id)).objectAt(0), // Get first matching progress
+      questions_promise = chapter.get('questions');
+
+    questions_promise.then((questions) => {
+      questions.forEach((parent_question) => {
+        let child_questions = parent_question.get('questions'); // Get child questions
+
+        if (child_questions.get('length')) {
+
+          let child_question = child_questions.objectAt(0),
+            tags = member.get('tags')
+            .filterBy('chapterId', parseInt(chapter.id))
+            .filterBy('questionId', parseInt(child_question.id)),
+            tag;
+
+          // Find the corresponding tag, or create it if it doesn't exist yet
+          if (tags.get('length')) {
+
+            // The tag exists, so use it
+            ///this.set('tag_input_condition', tags.objectAt(0)); //@TODO: Support having more than one child question
+            tag = tags.objectAt(0);
+          } else {
+
+            // The tag does not exist, so create it
+            tag = this.get('store').createRecord('tag', {
+              member: member,
+              chapterId: parseInt(chapter.id),
+              questionId: parseInt(child_question.id),
+              answer: [],
+            });
+          }
+
+          // Append child options to parent options
+          parent_question.get('options').pushObjects(child_question.get('options'));
+        }
+      });
+    });
+
+    if (! chapter_progress) {
+
+      // There is no progress marker for this chapter, so create one
+      chapter_progress = { chapter_id: parseInt(chapter.id), status: 'none', sequence_num: null};
+      progresses.pushObject(chapter_progress); // Add progress marker to the member
     }
   },
   model(params) {

--- a/app/routes/index/chapter.js
+++ b/app/routes/index/chapter.js
@@ -46,7 +46,7 @@ export default Ember.Route.extend({
           if (tags.get('length')) {
 
             // The tag exists, so use it
-            ///this.set('tag_input_condition', tags.objectAt(0)); //@TODO: Support having more than one child question
+            // @TODO: Support having more than one child question
             tag = tags.objectAt(0);
           } else {
 

--- a/app/routes/index/chapter/question.js
+++ b/app/routes/index/chapter/question.js
@@ -21,7 +21,10 @@ export default Ember.Route.extend({
 
     // We don't know the ID of the current question yet,
     // just that it's nth question on the current chapter.
-    var question = chapter.get('questions').objectAt(sequence_num - 1);
+    // And hidden questions are ignored in this flow.
+    var question = chapter.get('questions')
+      .rejectBy('type', 'hidden')
+      .objectAt(sequence_num - 1);
 
     // This is all the tags already received from the server plus the tags that were created from local storage, and
     // then filtered for only this chapter, and then filtered for only this question.
@@ -77,6 +80,18 @@ export default Ember.Route.extend({
 
       // Delete local storage for this tag
       this.set('storage.tag[' + member.id + '][' + chapter.id + '][' + question.id +']', tag.get('answer'));
+    },
+    updateTagCustom(member, chapter, question, option, tag, custom_value) {
+      Ember.Logger.log("Updating custom tag locally goes here...");
+
+      tag.set('answer', custom_value);
+
+      if (tag.get('answer').objectAt(0) !== null) {
+        tag.save(); // Persist data to API
+      }
+
+      // Update the ember-storage (localStorage or sessionStorage) value with tag value to keep them in sync
+      this.set('storage.tag[' + tag.get('member').get('id') + '][' + tag.get('chapterId') + '][' + tag.get('questionId') +']', tag.get('answer'));
     },
     updateTag(member, chapter, question, option, tag) {
       // Input fields use this to update the tag it's working on

--- a/app/services/pagination-nav.js
+++ b/app/services/pagination-nav.js
@@ -31,7 +31,7 @@ export default Ember.Service.extend({
     // Update pagination
     var next = chapter_progress.sequence_num + 1,
       prev = chapter_progress.sequence_num - 1,
-      total = chapter.get('questionsLength');
+      total = chapter.get('questions').rejectBy('type', 'hidden').get('length');
     next = (next > total ? false : next);
     prev = (prev < 1 ? false : prev);
     member.set('pagination', {

--- a/app/templates/components/answer-tile/custom-extra.hbs
+++ b/app/templates/components/answer-tile/custom-extra.hbs
@@ -1,0 +1,11 @@
+{{#each question.options as |option|}}
+  {{#if (if-eq option.text "__input-condition")}}
+      <li class="question-answer">
+        {{answer-tile/input updateTag=(route-action "updateTag" member chapter child_question option child_question_tag) option=option tag=child_question_tag}}
+      </li>
+  {{else}}
+      <li class="question-answer">
+        {{answer-tile saveTag=(action "saveTag" member chapter question option tag) question=question option=option tag=tag}}
+      </li>
+  {{/if}}
+{{/each}}

--- a/app/templates/components/answer-tile/custom-height.hbs
+++ b/app/templates/components/answer-tile/custom-height.hbs
@@ -1,0 +1,3 @@
+{{input type="text" class="form-control" value=option_feet.value}} feet
+
+{{input type="text" class="form-control" value=option_inches.value}} inches

--- a/app/templates/components/question-single.hbs
+++ b/app/templates/components/question-single.hbs
@@ -17,6 +17,14 @@
 <ul class="list-unstyled" style="margin-top: 24px">
   {{#if (if-eq question.type "select-dropdown")}}
     {{answer-tile/select saveTag=(route-action "saveTag" member chapter question 'null' tag) question=question option=option tag=tag}}
+  {{else if (if-eq question.type "custom-height")}}
+      <li class="question-answer">
+        {{component 'answer-tile/custom-height' updateTagCustom=(route-action "updateTagCustom" member chapter question 'null' tag) member=member chapter=chapter question=question tag=tag}}
+      </li>
+  {{else if (if-eq question.type "custom-extra")}}
+      <li class="question-answer">
+        {{component 'answer-tile/custom-extra' updateTagCustom=(route-action "updateTagCustom" member chapter question 'null') member=member chapter=chapter question=question tag=tag}}
+      </li>
   {{else}}
     {{#each question.options as |option|}}
       {{#if (if-eq question.type "input")}}

--- a/mirage/models/question.js
+++ b/mirage/models/question.js
@@ -3,4 +3,6 @@ import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 export default Model.extend({
   chapter: belongsTo('chapter'),
   options: hasMany('option'),
+  questions: hasMany('question', { inverse: 'question' }),
+  question: belongsTo('question', { inverse: 'questions' }),
 });

--- a/mirage/models/question.js
+++ b/mirage/models/question.js
@@ -3,6 +3,6 @@ import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 export default Model.extend({
   chapter: belongsTo('chapter'),
   options: hasMany('option'),
-  questions: hasMany('question', { inverse: 'question' }),
-  question: belongsTo('question', { inverse: 'questions' }),
+  questions: hasMany('question', { inverse: 'question' }), // Relationship to its child questions
+  question: belongsTo('question', { inverse: 'questions' }), // Relationship to its parent question
 });

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -4,15 +4,6 @@ export default function(server) {
 
   let member = server.schema.members.find(4); // Get member "lana"
 
-  server.create('response', {
-    memberId: 4,
-    surveyId: 102,
-    questions: {
-      questionId: 11,
-      questionNumber: -1,
-      response: ['127'],
-    },
-  });
 
   server.create('response', {
     memberId: 4,
@@ -130,81 +121,95 @@ export default function(server) {
   });
   // End question + its options
 
-  // Create a question + its options
-  question = chapter.createQuestion({
+  // Create a custom question + its options
+  var question_condition = chapter.createQuestion({
     title: "Previous or current conditions",
     description: "",
-    type: "select-multi",
+    type: "custom-extra",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "condition-01",
     text: "Condition 01",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "condition-02",
     text: "Condition 02",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "condition-03",
     text: "Condition 03",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "condition-04",
     text: "Condition 04",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "condition-05",
     text: "Condition 05",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "condition-A",
     text: "Condition A",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "condition-B",
     text: "Condition B",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "condition-C",
     text: "Condition C",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "condition-D",
     text: "Condition D",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "condition-E",
     text: "Condition E",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "condition-F",
     text: "Condition F",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "condition-G",
     text: "Condition G",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "__none-true",
     text: "None of the above",
   });
 
-  question.createOption({
+  question_condition.createOption({
     value: "__none-neutral",
     text: "I prefer not to answer",
+  });
+  // End question + its options
+
+  // Create a question + its options
+  var question_condition_extra = chapter.createQuestion({
+    title: "Any other previous or current conditions?",
+    description: "",
+    type: "hidden",
+    question: question_condition,
+  });
+
+  question_condition_extra.createOption({
+    value: "",
+    text: "__input-condition",
   });
   // End question + its options
 
@@ -295,16 +300,18 @@ export default function(server) {
   question = chapter.createQuestion({
     title: "How tall are you?",
     description: "",
-    type: "select-dropdown",
+    type: "custom-height",
   });
 
-  // Populate each week's option
-  for (let feet = 3; feet <= 7; feet++) {
+  question.createOption({
+    value: "", // Blank because it is a text input field
+    text: "__feet",
+  });
 
-    for (let inches = 0; inches <= 11; inches++) {
-      server.create('option', { value: ((feet * 12) + inches), text: feet +'ft ' + inches + ' in', question: question });
-    }
-  }
+  question.createOption({
+    value: "", // Blank because it is a text input field
+    text: "__inches",
+  });
   // End question + its options
 
   // Create a question + its options

--- a/tests/integration/components/answer-tile/custom-extra-test.js
+++ b/tests/integration/components/answer-tile/custom-extra-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('answer-tile/custom-extra', 'Integration | Component | answer tile/custom extra', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{answer-tile/custom-extra}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#answer-tile/custom-extra}}
+      template block text
+    {{/answer-tile/custom-extra}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/answer-tile/custom-height-test.js
+++ b/tests/integration/components/answer-tile/custom-height-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('answer-tile/custom-height', 'Integration | Component | answer tile/custom height', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{answer-tile/custom-height}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#answer-tile/custom-height}}
+      template block text
+    {{/answer-tile/custom-height}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
Feature: A question can be marked as `hidden`.

Question: `select-multi`
Custom option: 'None of the above' / 'Prefer not to say'
Feature: This option clears the other options and selects this one.

Question: custom question '`custom-height`'
Custom option: input option for feet, input option for inches
Feature: Creating an `answer-tile` child component called '`custom-height`' allows the custom-height component to munge the properties and pass individual options to the options components (in this case, the input component, one for feet, one for inches).

Question: custom question '`custom-extra`', and has one child question
Custom option: input option on the child question
Feature: A question can have a child question, with the child question marked as `hidden`. This allows questions to have multiple tags associated with them and still keep the 1-to-1 question/tag relationship in tact. The template can also use the options from both questions.

Creating an answer-tile child component called '`custom-extra`' allows the custom-extra component to:

1) find the child question (required for custom-extra questions)
2) find the child question's tag
3) use the child question's tag in the template, and save parts of the answer to both the parent question (the selected options) and child question (the input option).

This implementation only handles one specific customization of a question:
* multiple selectable options,
* followed by an input field,
* followed by 'None of the above' followed by 'Prefer not to say'.