### PR TITLE
Fix/no parseint ids

### DIFF
--- a/app/components/answer-tile/custom-extra.js
+++ b/app/components/answer-tile/custom-extra.js
@@ -14,8 +14,8 @@ export default Ember.Component.extend({
 
     // Find the tag corresponding to the child question
     let tags = member.get('tags')
-      .filterBy('chapterId', parseInt(chapter.id))
-      .filterBy('questionId', parseInt(child_question.id)),
+      .filterBy('chapterId', chapter.id)
+      .filterBy('questionId', child_question.id),
       tag;
 
     // Find the corresponding tag, or create it if it doesn't exist
@@ -28,8 +28,8 @@ export default Ember.Component.extend({
       // The tag does not exist yet, so create it
       tag = this.get('store').createRecord('tag', {
         member: member,
-        chapterId: parseInt(chapter.id),
-        questionId: parseInt(child_question.id),
+        chapterId: chapter.id,
+        questionId: child_question.id,
         answer: [],
       });
     }

--- a/app/routes/index/chapters/chapter/questions/question.js
+++ b/app/routes/index/chapters/chapter/questions/question.js
@@ -26,7 +26,7 @@ export default Ember.Route.extend({
         .objectAt(sequence_num - 1),
 
     // Get all of the chapter's tags
-      tags = this.modelFor('index/chapters/chapter').tags,
+      tags = member.get('tags'),
       tag,
 
     // Filter tags to only get this question's tag

--- a/app/serializers/member.js
+++ b/app/serializers/member.js
@@ -10,7 +10,7 @@ export default DS.JSONSerializer.extend({
     return {
       data: {
         type: 'member',
-        id: parseInt(member.id),
+        id: member.id,
         attributes: member,
       },
     };

--- a/app/services/member-consequences.js
+++ b/app/services/member-consequences.js
@@ -12,12 +12,12 @@ export default Ember.Service.extend({
     // Proceed to attempt to calculate BMI only if the BMI option exists
     if (bmi_option) {
       let bmi_question = bmi_option.get('question'),
-        bmi_tag = tags.filterBy('questionId', parseInt(bmi_question.get('id'))).objectAt(0),
+        bmi_tag = tags.filterBy('questionId', bmi_question.get('id')).objectAt(0),
         height_question = chapter.get('questions').filterBy('type', 'custom-height').objectAt(0), // Get custom height question's tag's answer
-        height_tag = tags.filterBy('questionId', parseInt(height_question.id)).objectAt(0),
+        height_tag = tags.filterBy('questionId', height_question.id).objectAt(0),
         height_value,
         weight_question = chapter.get('questions').filterBy('type', 'custom-weight').objectAt(0), // Get custom weight question
-        weight_tag = tags.filterBy('questionId', parseInt(weight_question.id)).objectAt(0),
+        weight_tag = tags.filterBy('questionId', weight_question.id).objectAt(0),
         weight_value;
 
       if (height_tag) {
@@ -33,8 +33,8 @@ export default Ember.Service.extend({
         // The tag does not exist yet, so create it
         bmi_tag = this.get('store').createRecord('tag', {
           member: member,
-          chapterId: parseInt(chapter.id),
-          questionId: parseInt(bmi_question.get('id')),
+          chapterId: chapter.id,
+          questionId: bmi_question.get('id'),
           answer: [],
         });
       }


### PR DESCRIPTION
All IDs are now get and set as strings, per spec. Also, the question gets the tags from the member, not from the chapter route.