### PR TITLE
Infra/reduce network/dont send savetag

### DIFF
--- a/app/routes/index/chapters/chapter/questions/question.js
+++ b/app/routes/index/chapters/chapter/questions/question.js
@@ -107,10 +107,6 @@ export default Ember.Route.extend({
 
       tag.set('answer', [option.get('value')]);
 
-      if (tag.get('answer').objectAt(0) !== null) {
-        tag.save(); // Persist data to API
-      }
-
       // Update the ember-storage (localStorage or sessionStorage) value with tag value to keep them in sync
       this.set('storage.tag[' + member.id + '][' + chapter.id + '][' + question.id +']', tag.get('answer'));
     },

--- a/app/routes/index/chapters/chapter/questions/question.js
+++ b/app/routes/index/chapters/chapter/questions/question.js
@@ -176,10 +176,6 @@ export default Ember.Route.extend({
 
       tag.set('answer', answers);
 
-      if (tag.get('answer').objectAt(0) !== null) {
-        tag.save(); // Persist data to API
-      }
-
       // Update the ember-storage (localStorage or sessionStorage) value with tag value to keep them in sync
       this.set('storage.tag[' + member.id + '][' + chapter.id + '][' + question.id +']', tag.get('answer'));
       return true;

--- a/app/routes/index/chapters/chapter/questions/question.js
+++ b/app/routes/index/chapters/chapter/questions/question.js
@@ -93,10 +93,6 @@ export default Ember.Route.extend({
 
       tag.set('answer', custom_value);
 
-      if (tag.get('answer').objectAt(0) !== null) {
-        tag.save(); // Persist data to API
-      }
-
       // Update the ember-storage (localStorage or sessionStorage) value with tag value to keep them in sync
       this.set('storage.tag[' + tag.get('member').get('id') + '][' + tag.get('chapterId') + '][' + tag.get('questionId') +']', tag.get('answer'));
     },


### PR DESCRIPTION
To reduce the number of network requests, the saving of tags on individual component actions has been removed. These saves will be done on the pagination transitions.