### PR TITLE
Feature/progress booleans

### DIFF
--- a/app/adapters/tag.js
+++ b/app/adapters/tag.js
@@ -54,7 +54,7 @@ export default JSONAPIAdapter.extend({
 
     //@TODO: Currently only supports one record at a time
     // "Deleting" a tag on the server is represented by updating the tag with a blank response and a score of 0
-    data.questions[0].response = "";
+    data.questions[0].response = [];
     data.questions[0].score = 0;
 
     return this.sendTag(store, type, data, url, 'POST'); // Solarium cannot accept verb 'DELETE'

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -12,7 +12,8 @@ export default Ember.Route.extend({
   },
   afterModel(model) {
     var member = model.member,
-      tags = model.tags;
+      tags = model.tags,
+      progresses = member.get('progresses'); // member's progress markers
 
     tags.forEach(function(tag) {
       tag.set('member', member); // Create tag/member relationship
@@ -51,17 +52,34 @@ export default Ember.Route.extend({
         }
       }
 
+      // Assign sequence numbers if the server hasn't already
       if (localStorage.key(i).indexOf('es__sequence_num') === 0){
         let sequence_nums_local = key.split(/[[\]]{1,2}/),
           chapterId = sequence_nums_local[2], // chapter ID of this progress marker
-          sequence_num = localStorage.getItem(key), // sequence_num of this progress marker
-          sequence_nums = member.get('progresses'); // member's progress markers
+          sequence_num = localStorage.getItem(key); // sequence number of this progress marker
 
-        // Check if this sequence_num already exists on the member
-        if (! sequence_nums.filterBy('chapter_id', chapterId).get('length')) {
+        for (let i = 0; i < progresses.length; i++) {
 
-          // If it is not, add it to member's sequence_num
-          sequence_nums.pushObject({ chapter_id: chapterId, sequence_num: sequence_num});
+          // Only update a sequence number if it belongs to this chapter and it is not already set by the server
+          if (progresses[i].chapter_id === chapterId && typeof progresses[i].sequence_num === 'undefined') {
+            progresses[i].sequence_num = sequence_num;
+          }
+        }
+      }
+
+      // Assign number of answers set if the server hasn't already
+      if (localStorage.key(i).indexOf('es__answers_set') === 0){
+        let answers_set_local = key.split(/[[\]]{1,2}/),
+          chapterId = answers_set_local[2], // chapter ID of this progress marker
+          answers_set = localStorage.getItem(key); // number of answers that have already been set of this progress marker
+
+        for (let i = 0; i < progresses.length; i++) {
+
+          // Only update the number of answers that have already been set if it belongs to this chapter and it is not
+          // already set by the server.
+          if (progresses[i].chapter_id === chapterId && typeof progresses[i].answers_set === 'undefined') {
+            progresses[i].answers_set = answers_set;
+          }
         }
       }
     }

--- a/app/routes/index/chapters/chapter.js
+++ b/app/routes/index/chapters/chapter.js
@@ -109,6 +109,7 @@ export default Ember.Route.extend({
         chapter_tags;
 
       chapter_progress.status = 'none'; // Update progress marker's status flag as 'none'
+      chapter_progress.answers_set = 0; // Reset answers_set to 0, because they are about to be deleted
       member.save(); // Explicitly save member because status is not observable
 
       chapter_tags = member.get('tags').filterBy('chapterId', chapter.id); // Get tags for this chapter

--- a/app/serializers/tag.js
+++ b/app/serializers/tag.js
@@ -33,7 +33,13 @@ export default DS.JSONSerializer.extend({
     var member = snapshot.belongsTo('member'), // Get the member that the tag belongs to
       chapter_id = snapshot.attr('chapterId'),
       progress = member.attr('progresses').filterBy('chapter_id', chapter_id).objectAt(0),
+      started,
       ended;
+
+    if (progress.first_tag_sent === true) {
+      started = true;
+      delete progress.first_tag_sent; // Remove flag, because it is only to be sent once
+    }
 
     // For Solarium use only; This does not affect summer-app in any way
     // Only send 'ended=true' flag if the member is in a state of 'completed' or 'unqualified'
@@ -42,6 +48,7 @@ export default DS.JSONSerializer.extend({
     }
 
     var json = {
+      started: started,
       ended: ended,
       surveyId: parseInt(snapshot.attr('chapterId')),
       questions: [{

--- a/app/serializers/tag.js
+++ b/app/serializers/tag.js
@@ -29,7 +29,20 @@ export default DS.JSONSerializer.extend({
   // Modify "tag" objects to become "response" objects.
   // Only used for sending data, such as: tag.save() .
   serialize: function(snapshot) {
+
+    var member = snapshot.belongsTo('member'), // Get the member that the tag belongs to
+      chapter_id = snapshot.attr('chapterId'),
+      progress = member.attr('progresses').filterBy('chapter_id', chapter_id).objectAt(0),
+      ended;
+
+    // For Solarium use only; This does not affect summer-app in any way
+    // Only send 'ended=true' flag if the member is in a state of 'completed' or 'unqualified'
+    if (progress.status === 'completed' || progress.status === 'unqualified') {
+      ended = true;
+    }
+
     var json = {
+      ended: ended,
       surveyId: parseInt(snapshot.attr('chapterId')),
       questions: [{
         questionId: snapshot.attr('questionId'),

--- a/app/services/member-consequences.js
+++ b/app/services/member-consequences.js
@@ -121,6 +121,9 @@ export default Ember.Service.extend({
     var progresses = member.get('progresses'),
       chapter_progress = progresses.filterBy('chapter_id', chapter.id).objectAt(0); // Get first matching progress
 
+    // answers_set resets to 0, and updates +1 for each non-empty tag that belongs to a non-hidden question
+    chapter_progress.answers_set = 0;
+
     if (chapter_progress.status === 'unqualified') {
 
       // An 'unqualified' member goes directly to Results page
@@ -158,6 +161,10 @@ export default Ember.Service.extend({
         question = chapter.get('questions').filterBy('id', questionId).objectAt(0);
 
       tag.set('score', 0); // Tag resets to 0 score, and updates its score from business logic
+
+      if (tag.get('answer').get('length') !== 0 && question.get('type') !== 'hidden') {
+        chapter_progress.answers_set++; // +1 to number of answers set thus far
+      }
 
       //@TODO: This is business logic, doesn't belong here
       switch (question.get('slug')) {

--- a/app/services/member-consequences.js
+++ b/app/services/member-consequences.js
@@ -119,7 +119,15 @@ export default Ember.Service.extend({
   calculate(member, chapter, consequence_links, route) {
 
     var progresses = member.get('progresses'),
-      chapter_progress = progresses.filterBy('chapter_id', chapter.id).objectAt(0); // Get first matching progress
+      chapter_progress = progresses.filterBy('chapter_id', chapter.id).objectAt(0), // Get first matching progress
+      potentially_first_tag_sent = false;
+
+    //@TODO: Only allow custom Solarium properties to be modified in the adapters and serializers
+    // Potentially mark this loop of calculations of the tags as the first for the chapter. This will be used to evaluate
+    // whether this loop caused the member to go from zero tags sent to more than zero tags sent.
+    if (chapter_progress.answers_set === 0) {
+      potentially_first_tag_sent = true;
+    }
 
     // answers_set resets to 0, and updates +1 for each non-empty tag that belongs to a non-hidden question
     chapter_progress.answers_set = 0;
@@ -347,6 +355,15 @@ export default Ember.Service.extend({
     this.calculatePreg35(member, chapter, tags);
 
     member.set('consequences', consequences);
+
+    //@TODO: Only allow custom Solarium properties to be modified in the adapters and serializers
+    // The first set of tags will be sent to Solarium only if
+    // 1) before these calculations were done, zero tags had been sent at that point, and
+    // 2) the # of answers that have been set at this point is now more than zero.
+    if (potentially_first_tag_sent === true && chapter_progress.answers_set > 0) {
+      chapter_progress.first_tag_sent = true; // Represents that started=true must be added to the payload of saved tags
+    }
+
     member.save();
 
     if (forwardToResults) {

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -4,26 +4,6 @@ export default function(server) {
 
   let member = server.schema.members.find(4); // Get member "lana"
 
-  server.create('response', {
-    memberId: 4,
-    surveyId: 102,
-    questions: {
-      questionId: '3',
-      questionNumber: -1,
-      response: ['18-34'],
-    },
-  });
-
-  server.create('response', {
-    memberId: 4,
-    surveyId: 102,
-    questions: {
-      questionId: '4',
-      questionNumber: -1,
-      response: [null],
-    },
-  });
-
   let chapter = server.schema.chapters.find(102);
 
   let question;


### PR DESCRIPTION
The first tag saved to Solarium is marked with the flag `started=true`. The last tag sent is marked with `ended=true`. There are two issues that need to be addressed later: 1) Custom Solarium properties shouldn't be polluting the app; they should only be in adapters and serializers. And 2) the started and ended flags are not exactly accurate. For example, ended may add itself to hidden questions' tags. Refactoring can be done on this if necessary.