### PR TITLE
Fix/score tag before save

### DIFF
--- a/app/adapters/tag.js
+++ b/app/adapters/tag.js
@@ -54,7 +54,7 @@ export default JSONAPIAdapter.extend({
 
     //@TODO: Currently only supports one record at a time
     // "Deleting" a tag on the server is represented by updating the tag with a blank response and a score of 0
-    data.questions[0].response = [];
+    data.questions[0].response = [].join();
     data.questions[0].score = 0;
 
     return this.sendTag(store, type, data, url, 'POST'); // Solarium cannot accept verb 'DELETE'

--- a/app/routes/index/chapters/chapter/questions/question.js
+++ b/app/routes/index/chapters/chapter/questions/question.js
@@ -172,7 +172,7 @@ export default Ember.Route.extend({
       this.set('storage.tag[' + member.id + '][' + chapter.id + '][' + question.id +']', tag.get('answer'));
       return true;
     },
-    saveTags(member) {
+    saveTags() {
       Ember.Logger.log("Saving all tags locally goes here...");
 
       //@TODO: member-consequences service does the tags loop with tag.save(), so this route action may no longer be needed.

--- a/app/routes/index/chapters/chapter/questions/question.js
+++ b/app/routes/index/chapters/chapter/questions/question.js
@@ -175,14 +175,7 @@ export default Ember.Route.extend({
     saveTags(member) {
       Ember.Logger.log("Saving all tags locally goes here...");
 
-      var tags = member.get('tags');
-
-      tags.forEach(function(tag) {
-
-        if (tag.get('answer').objectAt(0) !== null) {
-          tag.save(); // Persist data to API
-        }
-      });
+      //@TODO: member-consequences service does the tags loop with tag.save(), so this route action may no longer be needed.
     },
   }
 });

--- a/app/services/member-consequences.js
+++ b/app/services/member-consequences.js
@@ -350,7 +350,10 @@ export default Ember.Service.extend({
           break;
       }
 
-      tag.save();
+      // Don't save redacted tags
+      if (tag.get('answer').objectAt(0) !== null) {
+        tag.save(); // Persist data to API
+      }
     });
 
     this.calculateBmi(member, chapter, tags);

--- a/app/services/member-consequences.js
+++ b/app/services/member-consequences.js
@@ -349,6 +349,8 @@ export default Ember.Service.extend({
         default:
           break;
       }
+
+      tag.save();
     });
 
     this.calculateBmi(member, chapter, tags);


### PR DESCRIPTION
Move saving of tag to member-consequences so that they are all saved directly after evaluating all of the tags. Includes a "fix" to accommodate the current Solarium API which needs a string for response values.